### PR TITLE
Purpose of this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Build Process](https://github.com/cemu-project/Cemu/actions/workflows/build.yml/badge.svg)](https://github.com/cemu-project/Cemu/actions/workflows/build.yml)
 [![Discord](https://img.shields.io/discord/286429969104764928?label=Cemu&logo=discord&logoColor=FFFFFF)](https://discord.gg/5psYsup)
 [![Matrix Server](https://img.shields.io/matrix/cemu:cemu.info?server_fqdn=matrix.cemu.info&label=cemu:cemu.info&logo=matrix&logoColor=FFFFFF)](https://matrix.to/#/#cemu:cemu.info)
-
+.
 This is the code repository of Cemu, a Wii U emulator that is able to run most Wii U games and homebrew in a playable state.
 It's written in C/C++ and is being actively developed with new features and fixes.
 


### PR DESCRIPTION
What is the purpose of this repository?
You only share builds without providing any credit to the original developer of the fork.

Also you copied the same APK from the original fork.
It has the same hash as the APK from here https://github.com/SSimco/Cemu/releases/tag/32795e1
```
#sha256sum Cemu-32795e1.apk Cemu-Beta-V10.apk
adf94171f646acf2f0329c01a18efb05ea41e41e1ed0bbd4a2be816d647428fb  Cemu-32795e1.apk
adf94171f646acf2f0329c01a18efb05ea41e41e1ed0bbd4a2be816d647428fb  Cemu-Beta-V10.apk
```
And it's also signed with key from the original developer
```
#apksigner verify --verbose --print-certs Cemu-Beta-V10.apk
Verifies
Verified using v1 scheme (JAR signing): false
Verified using v2 scheme (APK Signature Scheme v2): true
Verified using v3 scheme (APK Signature Scheme v3): false
Verified using v3.1 scheme (APK Signature Scheme v3.1): false
Verified using v4 scheme (APK Signature Scheme v4): false
Verified for SourceStamp: false
Number of signers: 1
Signer #1 certificate DN: CN=SSimco, OU=Unknown, O=SSimco, L=Unknown, ST=Unknown, C=Unknown
Signer #1 certificate SHA-256 digest: 55d41ffc6b197c77958372301f529ca231ecd5b22bc83564de42087f4bcadb33
Signer #1 certificate SHA-1 digest: ea715ff5ba62cf88a99c52bda576b5a2addf9bb2
Signer #1 certificate MD5 digest: 8d2b7fb3c9a44e46957d08f06031eeb8
Signer #1 key algorithm: RSA
Signer #1 key size (bits): 4096
Signer #1 public key SHA-256 digest: ed1743121546347a2f911612bede867d5312713fa6e98312f39ccf55f5fb50ed
Signer #1 public key SHA-1 digest: 7050ed74e34210cbedda1ff5a628bf24bdb4b790
Signer #1 public key MD5 digest: 23958d93c8a06a75499d7560d455e7c9
```

At least compile it on your own and not just take it from the original fork or take down this repository if you can't put at least this much effort into it. 